### PR TITLE
Cambio de idMes a idMostrar

### DIFF
--- a/src/app/ejecucion/componentes/formulario-ejecucion/formulario-ejecucion.component.html
+++ b/src/app/ejecucion/componentes/formulario-ejecucion/formulario-ejecucion.component.html
@@ -63,7 +63,7 @@
             class="form-select"
             (ngModelChange)="manejarCambioDeMes($event)"
             [(ngModel)]="idMes">
-                <option [value]="mes.idMes" *ngFor="let mes of meses">{{ mes.idMes }} - {{ mes.nombreMes }}</option>
+                <option [value]="mes.idMes" *ngFor="let mes of meses">{{ mes.idMostrar }} - {{ mes.nombreMes }}</option>
             </select>
             <span class="validacion" *ngIf="!historico">Al enviar a ST, se enviará la información solo del mes seleccionado.</span>
         </fieldset>

--- a/src/app/encuestas/modelos/Mes.ts
+++ b/src/app/encuestas/modelos/Mes.ts
@@ -1,4 +1,5 @@
 export interface Mes{
     idMes: number
+    idMostrar: number
     nombreMes: string
 }


### PR DESCRIPTION
Se cambió la variable mostrada para que concordara con el mes mostrado en el periodo, en el formulario de ejecución.